### PR TITLE
Fix sidebar arrow when collapsed

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -138,4 +138,10 @@
   @media (min-width: breakpoint.$desktop) {
     display: flex;
   }
+
+  &.isSidebarOpen {
+    button img {
+      transform: rotate(180deg);
+    }
+  }
 }

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -90,7 +90,10 @@ export function SidebarNavigation() {
               iconSrc="/icons/arrow-left.svg"
               isCollapsed={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
-              className={styles.collapseMenuItem}
+              className={classNames(
+                styles.collapseMenuItem,
+                isSidebarCollapsed && styles.isSidebarOpen,
+              )}
             />
           </ul>
         </nav>


### PR DESCRIPTION
Fixed an issue where the arrow of the collapse button in the sidebar always displays as a left arrow instead of changing to a right arrow when the sidebar is collapsed