### PR TITLE
Fix logo resizing when switching to mobile view

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import { useContext, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { Routes } from "@config/routes";
 import classNames from "classnames";
 import { NavigationContext } from "./navigation-context";
@@ -20,6 +20,28 @@ export function SidebarNavigation() {
   const router = useRouter();
   const { isSidebarCollapsed, toggleSidebar } = useContext(NavigationContext);
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  useEffect(() => {
+    window.addEventListener("resize", onResize);
+    return () => {
+      window.removeEventListener("resize", onResize);
+    };
+  });
+
+  function onResize() {
+    if (isMobileView() && isSidebarCollapsed) {
+      toggleSidebar();
+    }
+  }
+
+  function isMobileView() {
+    const fontSize = 16;
+    const desktopBreakpoint = getComputedStyle(
+      document.documentElement,
+    ).getPropertyValue("--desktop-breakpoint");
+    return window.innerWidth <= parseInt(desktopBreakpoint) * fontSize;
+  }
+
   return (
     <div
       className={classNames(
@@ -37,7 +59,7 @@ export function SidebarNavigation() {
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={
-              isSidebarCollapsed
+              isSidebarCollapsed && !isMobileView()
                 ? "/icons/logo-small.svg"
                 : "/icons/logo-large.svg"
             }

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -1,4 +1,9 @@
 @use "color";
+@use "breakpoint";
+
+:root {
+  --desktop-breakpoint: #{breakpoint.$desktop};
+}
 
 body {
   font-family: Inter, sans-serif;


### PR DESCRIPTION
Fixes an issue where the main logo would not display correctly if, in desktop view, the sidebar is collapsed and then the view is changed to mobile view. Also fixes an issue where, when those events happen, and then the mobile menu is opened, the menu items have no text.